### PR TITLE
Add CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+This is the blog for the OCaml Platform project.
+The following is how we write and publish posts.
+
+1. All work is done on this one repo, so avoid making forks. Only contributors have push access.
+2. Each blog post gets its own branch
+3. Please use 'sensible' line breaks (see note below)
+4. Once a draft is ready for review, submit a **PR** to `master`.
+5. Other folks can comment on the PR using the GitHub interface.
+6. Ideally only *one person* incorporates the feedback and pushes changes
+7. If anyone else really needs to push changes, make it *very* clear in the comments that you are about to do so *and* when you are done.
+8. Last person to review will note this in the comments, make final edits and merge.
+
+****
+
+When we say 'sensible line breaks', please use your judgement.
+We're specifically trying to **avoid** the following problems:
+
+- *Paragraphs per line*: This makes it difficult to point out specific changes and comments begin to overlap.
+- *People re-doing the line breaks*: Unless done as a separate commit, changes become difficult to read between diffs.


### PR DESCRIPTION
This is a reminder of how we will create blog posts.
It's intended to avoid the scenario where a PR from a fork
needs changes and someone else creates a _new_ PR with those
changes. Instead, all contributors have push access to this repo.
