### PR TITLE
minor: gender-neutral attacker

### DIFF
--- a/Signing-the-opam-repository.md
+++ b/Signing-the-opam-repository.md
@@ -108,7 +108,7 @@ to not realize there is anything wrong.
   from good mirrors.
 
 - Wrong author attack: an attacker should not be able to upload a new
-  version of a package for which he is not the real maintainer.
+  version of a package for which they are not the real maintainer.
 
 ## Trust
 


### PR DESCRIPTION
English is amusingly gender-neutral, and I think it's good to preserve that property -- this was the only change needed to do so in this text.