### PR TITLE
Update the command to install opam to point to the new simplified url on opam.ocaml.org

### DIFF
--- a/opam-2-0-0-rc.md
+++ b/opam-2-0-0-rc.md
@@ -14,7 +14,7 @@ You are invited to read the [beta5 announcement](https://opam.ocaml.org/blog/opa
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.0-rc) to your PATH.

--- a/opam-2-0-0-rc2.md
+++ b/opam-2-0-0-rc2.md
@@ -21,7 +21,7 @@ Installation instructions:
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.0-rc2) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed.

--- a/opam-2-0-0-rc3.md
+++ b/opam-2-0-0-rc3.md
@@ -20,7 +20,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.0-rc3) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed.

--- a/opam-2-0-0-rc4.md
+++ b/opam-2-0-0-rc4.md
@@ -22,7 +22,7 @@ Installation instructions:
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.0-rc4) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed.

--- a/opam-2-0-0.md
+++ b/opam-2-0-0.md
@@ -29,7 +29,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.0) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed.

--- a/opam-2-0-1.md
+++ b/opam-2-0-1.md
@@ -32,7 +32,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.1) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed.

--- a/opam-2-0-10-2-1-1-depext.md
+++ b/opam-2-0-10-2-1-1-depext.md
@@ -71,7 +71,7 @@ Opam installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.1"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.1"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.1) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-2.md
+++ b/opam-2-0-2.md
@@ -44,7 +44,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.2) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update your sandbox script.

--- a/opam-2-0-3.md
+++ b/opam-2-0-3.md
@@ -20,7 +20,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.3) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-4.md
+++ b/opam-2-0-4.md
@@ -36,7 +36,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.4) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-5.md
+++ b/opam-2-0-5.md
@@ -29,7 +29,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.5) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-6.md
+++ b/opam-2-0-6.md
@@ -38,7 +38,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.0.6"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.0.6"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.6) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-7.md
+++ b/opam-2-0-7.md
@@ -21,7 +21,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.0.7"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.0.7"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.7) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-8.md
+++ b/opam-2-0-8.md
@@ -28,7 +28,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.0.8"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.0.8"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.8) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-9.md
+++ b/opam-2-0-9.md
@@ -38,7 +38,7 @@ Installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.0.9"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.0.9"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.0.9) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-0-beta5.md
+++ b/opam-2-0-beta5.md
@@ -62,7 +62,7 @@ There are three main ways to get the update:
    back:
 
     ```
-    sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+    sh <(curl -sL https://opam.ocaml.org/install.sh)
     ```
 
    This uses the binaries from https://github.com/ocaml/opam/releases/tag/2.0.0-beta5

--- a/opam-2-1-0-alpha.md
+++ b/opam-2-1-0-alpha.md
@@ -119,7 +119,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.0~alpha"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.0~alpha"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.0-alpha) to your PATH.

--- a/opam-2-1-0-rc2.md
+++ b/opam-2-1-0-rc2.md
@@ -25,7 +25,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.0~rc2"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.0~rc2"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.0-rc2) to your PATH.

--- a/opam-2-1-0.md
+++ b/opam-2-1-0.md
@@ -272,7 +272,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.0"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.0"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.0) to your PATH.

--- a/opam-2-1-2.md
+++ b/opam-2-1-2.md
@@ -24,7 +24,7 @@ Opam installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.2"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.2"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.2) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-1-3.md
+++ b/opam-2-1-3.md
@@ -38,7 +38,7 @@ Opam installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.3"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.3"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.3) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-1-4-publish-file-format.md
+++ b/opam-2-1-4-publish-file-format.md
@@ -37,7 +37,7 @@ Opam installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.4"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.4"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.4) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-1-5.md
+++ b/opam-2-1-5.md
@@ -26,7 +26,7 @@ Opam installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.5"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.5"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.5) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-1-6.md
+++ b/opam-2-1-6.md
@@ -29,7 +29,7 @@ Opam installation instructions (unchanged):
 1. From binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.1.6"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.1.6"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.1.6) to your PATH. In this case, don't forget to run `opam init --reinit -ni` to enable sandboxing if you had version 2.0.0~rc manually installed or to update you sandbox script.

--- a/opam-2-2-0-alpha.md
+++ b/opam-2-2-0-alpha.md
@@ -340,7 +340,7 @@ The upgrade instructions are unchanged:
 
 1. From binaries: run
 ```
-bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~alpha"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~alpha"
 ```
 Or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-alpha) to your PATH.
 

--- a/opam-2-2-0-alpha2.md
+++ b/opam-2-2-0-alpha2.md
@@ -77,7 +77,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~alpha2"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~alpha2"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-alpha2) to your PATH.

--- a/opam-2-2-0-alpha3.md
+++ b/opam-2-2-0-alpha3.md
@@ -132,7 +132,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~alpha3"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~alpha3"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-alpha3) to your PATH.

--- a/opam-2-2-0-beta1.md
+++ b/opam-2-2-0-beta1.md
@@ -90,7 +90,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~beta1"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~beta1"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-beta1) to your PATH.

--- a/opam-2-2-0-beta2.md
+++ b/opam-2-2-0-beta2.md
@@ -129,7 +129,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~beta2"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~beta2"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-beta2) to your PATH.

--- a/opam-2-2-0-beta3.md
+++ b/opam-2-2-0-beta3.md
@@ -61,7 +61,7 @@ The upgrade instructions are unchanged:
 1. Either from binaries: run
 
     ```
-    bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~beta3"
+    bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~beta3"
     ```
 
     or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-beta3) to your PATH.

--- a/opam-2-2-0-rc1.md
+++ b/opam-2-2-0-rc1.md
@@ -37,11 +37,11 @@ The upgrade instructions are unchanged:
 
 For Unix systems
 ```
-bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0~rc1"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0~rc1"
 ```
 or from PowerShell for Windows systems
 ```
-Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1) }"
+Invoke-Expression "& { $(Invoke-RestMethod https://opam.ocaml.org/install.ps1) }"
 ```
 or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0-rc1) to your PATH.
 

--- a/opam-2-2-0.md
+++ b/opam-2-2-0.md
@@ -22,11 +22,11 @@ The upgrade instructions are unchanged:
 
 For Unix systems
 ```
-bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.0"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.0"
 ```
 or from PowerShell for Windows systems
 ```
-Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1) }"
+Invoke-Expression "& { $(Invoke-RestMethod https://opam.ocaml.org/install.ps1) }"
 ```
 or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.0) to your PATH.
 

--- a/opam-2-2-1.md
+++ b/opam-2-2-1.md
@@ -36,11 +36,11 @@ The upgrade instructions are unchanged:
 
 For Unix systems
 ```
-bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.2.1"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.2.1"
 ```
 or from PowerShell for Windows systems
 ```
-Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1) }"
+Invoke-Expression "& { $(Invoke-RestMethod https://opam.ocaml.org/install.ps1) }"
 ```
 (or via `winget upgrade OCaml.opam`) or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.2.1) to your PATH.
 

--- a/opam-2-3-0-alpha1.md
+++ b/opam-2-3-0-alpha1.md
@@ -69,11 +69,11 @@ The upgrade instructions are unchanged:
 
 For Unix systems
 ```
-bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --version 2.3.0~alpha1"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh) --version 2.3.0~alpha1"
 ```
 or from PowerShell for Windows systems
 ```
-Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1) } -Version 2.3.0~alpha1"
+Invoke-Expression "& { $(Invoke-RestMethod https://opam.ocaml.org/install.ps1) } -Version 2.3.0~alpha1"
 ```
 or download manually from [the Github "Releases" page](https://github.com/ocaml/opam/releases/tag/2.3.0-alpha1) to your PATH.
 


### PR DESCRIPTION
Now that the url exists following https://github.com/ocaml-opam/opam2web/pull/241
Similar PRs have been sent to https://github.com/ocaml/ocaml.org/pull/2741 and https://github.com/ocaml/opam/pull/6226